### PR TITLE
Fix generated project compile error: Add imports required for CachingHeaders

### DIFF
--- a/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/server/AutoHeadResponseFeature.kt
+++ b/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/server/AutoHeadResponseFeature.kt
@@ -31,6 +31,8 @@ object AutoHeadResponseFeature : ServerFeature(ApplicationKt) {
 
     override fun BlockBuilder.renderFeature(info: BuildInfo) {
         addImport("io.ktor.features.*")
+        addImport("io.ktor.http.*")
+        addImport("io.ktor.http.content.*")
         addImport("io.ktor.util.date.*")
         addFeatureInstall {
             "install(CachingHeaders)" {


### PR DESCRIPTION
Ticking the CachingHeaders feature on https://start.ktor.io currently produces a project that fails to compile (eg using `./gradlew assemble`) with these errors:

```
e: /home/user/ktor-demo/src/Application.kt: (17, 17): Unresolved reference: ContentType
e: /home/user/ktor-demo/src/Application.kt: (17, 41): Unresolved reference: CachingOptions
e: /home/user/ktor-demo/src/Application.kt: (17, 56): Unresolved reference: CacheControl
```

This pull request adds the required imports to the generated project to make it successfully build.