### PR TITLE
 use fullPath instead of encodedPath

### DIFF
--- a/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/client/ClientEngines.kt
+++ b/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/client/ClientEngines.kt
@@ -104,8 +104,7 @@ object MockClientEngine : ClientEngine(CoreClientEngine, ApplicationTestKt) {
                         +"engine" {
                             +"addHandler { request -> "
                             indent{
-                                +"@UseExperimental(InternalAPI::class)"
-                                +"when (request.url.encodedPath)" {
+                                +"when (request.url.fullPath)" {
                                     +"\"/\" -> respond("
                                         indent {
                                             +"ByteReadChannel(byteArrayOf(1, 2, 3)),"


### PR DESCRIPTION
supplement to #13, should have used fullPath from the beginning.
As with #13 I wrote this via the web UI of GitHub no guarantee it works