### PR TITLE
Upgrade gradle to 5.6.2

### DIFF
--- a/docs/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/docs/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/docs/gradle/gradle/wrapper/gradle-wrapper.properties.kotlin-dsl
+++ b/docs/gradle/gradle/wrapper/gradle-wrapper.properties.kotlin-dsl
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/docs/ktor-generator.js
+++ b/docs/ktor-generator.js
@@ -10328,12 +10328,12 @@
       tmp$ = get_compileDependencies(this$render).iterator();
       while (tmp$.hasNext()) {
         var dep = tmp$.next();
-        $receiver.line_61zpoe$('compile(' + '"' + dep.dependency + '"' + ')');
+        $receiver.line_61zpoe$('implementation(' + '"' + dep.dependency + '"' + ')');
       }
       tmp$_0 = minus(get_testDependencies(this$render), get_compileDependencies(this$render)).iterator();
       while (tmp$_0.hasNext()) {
         var dep_0 = tmp$_0.next();
-        $receiver.line_61zpoe$('testCompile(' + '"' + dep_0.dependency + '"' + ')');
+        $receiver.line_61zpoe$('testImplementation(' + '"' + dep_0.dependency + '"' + ')');
       }
       return Unit;
     };
@@ -10527,12 +10527,12 @@
       tmp$ = get_compileDependencies(this$render).iterator();
       while (tmp$.hasNext()) {
         var dep = tmp$.next();
-        $receiver.line_61zpoe$('compile ' + '"' + dep.dependency + '"');
+        $receiver.line_61zpoe$('implementation ' + '"' + dep.dependency + '"');
       }
       tmp$_0 = minus(get_testDependencies(this$render), get_compileDependencies(this$render)).iterator();
       while (tmp$_0.hasNext()) {
         var dep_0 = tmp$_0.next();
-        $receiver.line_61zpoe$('testCompile ' + '"' + dep_0.dependency + '"');
+        $receiver.line_61zpoe$('testImplementation ' + '"' + dep_0.dependency + '"');
       }
       return Unit;
     };

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ktor-generator/src/commonMain/kotlin/io/ktor/start/project/BuildFilesGradle.kt
+++ b/ktor-generator/src/commonMain/kotlin/io/ktor/start/project/BuildFilesGradle.kt
@@ -61,10 +61,10 @@ internal class BuildFilesGradle(val kotlin: Boolean) : BuildInfoBlock() {
                     linedeferred {
                         println("compileDependencies: $compileDependencies")
                         for (dep in compileDependencies) {
-                            +"compile(\"${dep.dependency}\")"
+                            +"implementation(\"${dep.dependency}\")"
                         }
                         for (dep in testDependencies - compileDependencies) {
-                            +"testCompile(\"${dep.dependency}\")"
+                            +"testImplementation(\"${dep.dependency}\")"
                         }
                     }
                 }
@@ -117,10 +117,10 @@ internal class BuildFilesGradle(val kotlin: Boolean) : BuildInfoBlock() {
                     linedeferred {
                         println("compileDependencies: $compileDependencies")
                         for (dep in compileDependencies) {
-                            +"compile \"${dep.dependency}\""
+                            +"implementation \"${dep.dependency}\""
                         }
                         for (dep in testDependencies - compileDependencies) {
-                            +"testCompile \"${dep.dependency}\""
+                            +"testImplementation \"${dep.dependency}\""
                         }
                     }
                 }

--- a/ktor-generator/src/commonMain/resources/gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/ktor-generator/src/commonMain/resources/gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ktor-generator/src/commonMain/resources/gradle/gradle/wrapper/gradle-wrapper.properties.kotlin-dsl
+++ b/ktor-generator/src/commonMain/resources/gradle/gradle/wrapper/gradle-wrapper.properties.kotlin-dsl
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR contains the following changes. I believe they will provide better Gradle experience to generator user.

## Changes

* Upgrade gradle versions to 5.6.2 in both project itself and generated project.
  * There are many improvements in Gradle 5.x including better Kotlin DSL support. https://gradle.org/whats-new/gradle-5/
* Replace deprecated `compile`/`testCompile` with `implementation`/`testImplementation`.
  * https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management

