### PR TITLE
Fix buildscript generation for 'CIO HttpClient Engine' feature

### DIFF
--- a/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/client/ClientEngines.kt
+++ b/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/client/ClientEngines.kt
@@ -60,6 +60,13 @@ object CioClientEngine : ClientEngine(CoreClientEngine) {
     override val description = "Engine for the Ktor HttpClient using CIO (Corroutine I/O). Only supports HTTP 1.x."
     override val documentation = "https://ktor.io/clients/http-client.html#cio"
 
+    override val artifacts: List<String> by lazy {
+        listOf(
+            "io.ktor:ktor-client-cio:\$ktor_version",
+            "io.ktor:ktor-client-cio-jvm:\$ktor_version"
+        )
+    }
+    
     override fun BlockBuilder.renderFeature(info: BuildInfo) {
         addImport("io.ktor.client.engine.cio.*")
         clientEngine = "CIO"


### PR DESCRIPTION
Add missing 'io.ktor:ktor-client-cio-jvm' dependency