### PR TITLE
Swap CachingHeadersFeature and AutoHeadResponseFeature file content

### DIFF
--- a/docs/ktor-generator.js
+++ b/docs/ktor-generator.js
@@ -5653,10 +5653,10 @@
     ServerFeature.call(this, [ApplicationKt_getInstance()]);
     this.repos_kzw2lb$_0 = Repos_getInstance().ktor;
     this.artifacts_g2pl8f$_0 = listOf('io.ktor:ktor-server-core:$ktor_version');
-    this.id_uzkfxz$_0 = 'caching-headers';
-    this.title_jzj61i$_0 = 'CachingHeaders';
-    this.description_fp9286$_0 = 'Send the headers Cache-Control and Expires used by clients and proxies to cache requests';
-    this.documentation_felmrc$_0 = 'https://ktor.io/docs/caching-headers.html';
+    this.id_uzkfxz$_0 = 'auto-head-response';
+    this.title_jzj61i$_0 = 'AutoHeadResponse';
+    this.description_fp9286$_0 = 'Provide responses to HEAD requests for existing routes that have the GET verb defined';
+    this.documentation_felmrc$_0 = 'https://ktor.io/docs/autoheadresponse.html';
   }
   Object.defineProperty(AutoHeadResponseFeature.prototype, 'repos', {
     get: function () {
@@ -5689,40 +5689,11 @@
     }
   });
   function AutoHeadResponseFeature$renderFeature$lambda($receiver) {
-    var $receiver_0 = 'install(CachingHeaders)';
-    var rafter = ''.length === 0 ? '' : ' ' + '';
-    $receiver.line_61zpoe$($receiver_0.length === 0 ? '{' + rafter : $receiver_0 + ' {' + rafter);
-    $receiver._indent();
-    try {
-      $receiver.line_61zpoe$('options { outgoingContent ->');
-      $receiver._indent();
-      try {
-        var $receiver_1 = 'when (outgoingContent.contentType?.withoutParameters())';
-        var rafter_0 = ''.length === 0 ? '' : ' ' + '';
-        $receiver.line_61zpoe$($receiver_1.length === 0 ? '{' + rafter_0 : $receiver_1 + ' {' + rafter_0);
-        $receiver._indent();
-        try {
-          $receiver.line_61zpoe$('ContentType.Text.CSS -> CachingOptions(CacheControl.MaxAge(maxAgeSeconds = 24 * 60 * 60), expires = null as? GMTDate?)');
-          $receiver.line_61zpoe$('else -> null');
-        }finally {
-          $receiver._unindent();
-        }
-        $receiver.line_61zpoe$('}' + '');
-      }finally {
-        $receiver._unindent();
-      }
-      $receiver.line_61zpoe$('}');
-    }finally {
-      $receiver._unindent();
-    }
-    $receiver.line_61zpoe$('}' + '');
+    $receiver.line_61zpoe$('install(AutoHeadResponse)');
     return Unit;
   }
   AutoHeadResponseFeature.prototype.renderFeature_gtq0m3$ = function ($receiver, info) {
     addImport($receiver, 'io.ktor.features.*');
-    addImport($receiver, 'io.ktor.http.*');
-    addImport($receiver, 'io.ktor.http.content.*');
-    addImport($receiver, 'io.ktor.util.date.*');
     addFeatureInstall($receiver, AutoHeadResponseFeature$renderFeature$lambda);
   };
   AutoHeadResponseFeature.$metadata$ = {
@@ -5816,10 +5787,10 @@
     ServerFeature.call(this, [ApplicationKt_getInstance()]);
     this.repos_go8v1k$_0 = Repos_getInstance().ktor;
     this.artifacts_4n8blk$_0 = listOf('io.ktor:ktor-server-core:$ktor_version');
-    this.id_894vts$_0 = 'auto-head-response';
-    this.title_fnvyhr$_0 = 'AutoHeadResponse';
-    this.description_vh4wqr$_0 = 'Provide responses to HEAD requests for existing routes that have the GET verb defined';
-    this.documentation_z7p4ld$_0 = 'https://ktor.io/docs/autoheadresponse.html';
+    this.id_894vts$_0 = 'caching-headers';
+    this.title_fnvyhr$_0 = 'CachingHeaders';
+    this.description_vh4wqr$_0 = 'Send the headers Cache-Control and Expires used by clients and proxies to cache requests';
+    this.documentation_z7p4ld$_0 = 'https://ktor.io/docs/caching-headers.html';
   }
   Object.defineProperty(CachingHeadersFeature.prototype, 'repos', {
     get: function () {
@@ -5852,11 +5823,40 @@
     }
   });
   function CachingHeadersFeature$renderFeature$lambda($receiver) {
-    $receiver.line_61zpoe$('install(AutoHeadResponse)');
+    var $receiver_0 = 'install(CachingHeaders)';
+    var rafter = ''.length === 0 ? '' : ' ' + '';
+    $receiver.line_61zpoe$($receiver_0.length === 0 ? '{' + rafter : $receiver_0 + ' {' + rafter);
+    $receiver._indent();
+    try {
+      $receiver.line_61zpoe$('options { outgoingContent ->');
+      $receiver._indent();
+      try {
+        var $receiver_1 = 'when (outgoingContent.contentType?.withoutParameters())';
+        var rafter_0 = ''.length === 0 ? '' : ' ' + '';
+        $receiver.line_61zpoe$($receiver_1.length === 0 ? '{' + rafter_0 : $receiver_1 + ' {' + rafter_0);
+        $receiver._indent();
+        try {
+          $receiver.line_61zpoe$('ContentType.Text.CSS -> CachingOptions(CacheControl.MaxAge(maxAgeSeconds = 24 * 60 * 60), expires = null as? GMTDate?)');
+          $receiver.line_61zpoe$('else -> null');
+        }finally {
+          $receiver._unindent();
+        }
+        $receiver.line_61zpoe$('}' + '');
+      }finally {
+        $receiver._unindent();
+      }
+      $receiver.line_61zpoe$('}');
+    }finally {
+      $receiver._unindent();
+    }
+    $receiver.line_61zpoe$('}' + '');
     return Unit;
   }
   CachingHeadersFeature.prototype.renderFeature_gtq0m3$ = function ($receiver, info) {
     addImport($receiver, 'io.ktor.features.*');
+    addImport($receiver, 'io.ktor.http.*');
+    addImport($receiver, 'io.ktor.http.content.*');
+    addImport($receiver, 'io.ktor.util.date.*');
     addFeatureInstall($receiver, CachingHeadersFeature$renderFeature$lambda);
   };
   CachingHeadersFeature.$metadata$ = {

--- a/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/server/AutoHeadResponseFeature.kt
+++ b/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/server/AutoHeadResponseFeature.kt
@@ -24,27 +24,15 @@ import io.ktor.start.util.*
 object AutoHeadResponseFeature : ServerFeature(ApplicationKt) {
     override val repos = Repos.ktor
     override val artifacts = listOf("io.ktor:ktor-server-core:\$ktor_version")
-    override val id = "caching-headers"
-    override val title = "CachingHeaders"
-    override val description = "Send the headers Cache-Control and Expires used by clients and proxies to cache requests"
-    override val documentation = "https://ktor.io/docs/caching-headers.html"
+    override val id = "auto-head-response"
+    override val title = "AutoHeadResponse"
+    override val description = "Provide responses to HEAD requests for existing routes that have the GET verb defined"
+    override val documentation = "https://ktor.io/docs/autoheadresponse.html"
 
     override fun BlockBuilder.renderFeature(info: BuildInfo) {
         addImport("io.ktor.features.*")
-        addImport("io.ktor.http.*")
-        addImport("io.ktor.http.content.*")
-        addImport("io.ktor.util.date.*")
         addFeatureInstall {
-            "install(CachingHeaders)" {
-                +"options { outgoingContent ->"
-                indent {
-                    "when (outgoingContent.contentType?.withoutParameters())" {
-                        +"ContentType.Text.CSS -> CachingOptions(CacheControl.MaxAge(maxAgeSeconds = 24 * 60 * 60), expires = null as? GMTDate?)"
-                        +"else -> null"
-                    }
-                }
-                +"}"
-            }
+            +"install(AutoHeadResponse)"
         }
     }
 }

--- a/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/server/CachingHeadersFeature.kt
+++ b/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/server/CachingHeadersFeature.kt
@@ -24,15 +24,27 @@ import io.ktor.start.util.*
 object CachingHeadersFeature : ServerFeature(ApplicationKt) {
     override val repos = Repos.ktor
     override val artifacts = listOf("io.ktor:ktor-server-core:\$ktor_version")
-    override val id = "auto-head-response"
-    override val title = "AutoHeadResponse"
-    override val description = "Provide responses to HEAD requests for existing routes that have the GET verb defined"
-    override val documentation = "https://ktor.io/docs/autoheadresponse.html"
+    override val id = "caching-headers"
+    override val title = "CachingHeaders"
+    override val description = "Send the headers Cache-Control and Expires used by clients and proxies to cache requests"
+    override val documentation = "https://ktor.io/docs/caching-headers.html"
 
     override fun BlockBuilder.renderFeature(info: BuildInfo) {
         addImport("io.ktor.features.*")
+        addImport("io.ktor.http.*")
+        addImport("io.ktor.http.content.*")
+        addImport("io.ktor.util.date.*")
         addFeatureInstall {
-            +"install(AutoHeadResponse)"
+            "install(CachingHeaders)" {
+                +"options { outgoingContent ->"
+                indent {
+                    "when (outgoingContent.contentType?.withoutParameters())" {
+                        +"ContentType.Text.CSS -> CachingOptions(CacheControl.MaxAge(maxAgeSeconds = 24 * 60 * 60), expires = null as? GMTDate?)"
+                        +"else -> null"
+                    }
+                }
+                +"}"
+            }
         }
     }
 }


### PR DESCRIPTION
Currently, the contents of the files CachingHeadersFeature.kt and AutoHeadResponseFeature.kt are swapped.

This PR puts the contents of the feature classes into their intended files. 