### PR TITLE
Add missing ContentNegotiationFeature features import

### DIFF
--- a/docs/ktor-generator.js
+++ b/docs/ktor-generator.js
@@ -6149,6 +6149,7 @@
     };
   }
   ContentNegotiationFeature.prototype.renderFeature_gtq0m3$ = function ($receiver, info) {
+    addImport($receiver, 'io.ktor.features.*');
     addFeatureInstall($receiver, ContentNegotiationFeature$renderFeature$lambda(this, $receiver));
   };
   ContentNegotiationFeature.$metadata$ = {

--- a/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/server/ContentNegotiationFeature.kt
+++ b/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/server/ContentNegotiationFeature.kt
@@ -34,6 +34,7 @@ object ContentNegotiationFeature : ServerFeature(ApplicationKt) {
     val BLOCK = newSlot("BLOCK")
 
     override fun BlockBuilder.renderFeature(info: BuildInfo) {
+        addImport("io.ktor.features.*")
         addFeatureInstall {
             "install(ContentNegotiation)" {
                block(BLOCK)


### PR DESCRIPTION
Currently, when no other feature then _ContentNegotiation_ is selected, the generated project is not compilable since it is missing the `io.ktor.features.*` import. 

This PR adds the required import to the `ContentNegotiationFeature` code. References issue #26.

