### PR TITLE
Add conditional import for ByteReadChannel in MockEngine test code

### DIFF
--- a/docs/ktor-generator.js
+++ b/docs/ktor-generator.js
@@ -4663,9 +4663,13 @@
     addTestImport($receiver, 'io.ktor.client.engine.mock.*');
     addTestImport($receiver, 'kotlinx.coroutines.experimental.*');
     addTestImport($receiver, 'io.ktor.http.*');
-    addTestImport($receiver, 'kotlinx.coroutines.experimental.io.*');
     addTestImport($receiver, 'io.ktor.client.request.*');
     addTestImport($receiver, 'io.ktor.client.call.*');
+    if (info.ktorVersion.compareTo_11rb$(Versions_getInstance().V130) >= 0) {
+      addTestImport($receiver, 'io.ktor.utils.io.*');
+    } else {
+      addTestImport($receiver, 'kotlinx.coroutines.experimental.io.*');
+    }
     addTestMethod($receiver, 'testClientMock', MockClientEngine$renderFeature$lambda(info));
   };
   MockClientEngine.$metadata$ = {

--- a/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/client/ClientEngines.kt
+++ b/ktor-generator/src/commonMain/kotlin/io/ktor/start/features/client/ClientEngines.kt
@@ -92,9 +92,13 @@ object MockClientEngine : ClientEngine(CoreClientEngine, ApplicationTestKt) {
         addTestImport("io.ktor.client.engine.mock.*")
         addTestImport("kotlinx.coroutines.experimental.*")
         addTestImport("io.ktor.http.*")
-        addTestImport("kotlinx.coroutines.experimental.io.*")
         addTestImport("io.ktor.client.request.*")
         addTestImport("io.ktor.client.call.*")
+        if (info.ktorVersion >= Versions.V130) {
+            addTestImport("io.ktor.utils.io.*")
+        } else {
+            addTestImport("kotlinx.coroutines.experimental.io.*")
+        }
 
         addTestMethod("testClientMock") {
             +"runBlocking" {


### PR DESCRIPTION
Currently, the test code generation imports `kotlinx.coroutines.experimental.io.*`, required by `ByteReadChannel` for all Ktor versions. From ktor 1.3.0 the API changed and `ByteReadChannel` is now located under `io.ktor.utils.io.* `. As a result, generated Ktor projects (version >= 1.3.0) using the Mock HttpClient Engine do not compile.

This PR addresses #27 and points `ByteReadChannel` to the correct import depending on the selected Ktor version.